### PR TITLE
US036 Push API to AWS - Hotfix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,11 +4,10 @@ on:
   pull_request:
     branches:
       - main
-      - ready-for-sign-off
+      
   push:
     branches:
       - main
-      - ready-for-sign-off
 
 jobs:
 


### PR DESCRIPTION
This is a hot-fix so that the Docker API image pushes on push to ready-for-sign-off and main only.